### PR TITLE
Remove encoding declaration from XML view

### DIFF
--- a/server_environment/serv_config.py
+++ b/server_environment/serv_config.py
@@ -199,8 +199,7 @@ class ServerConfiguration(models.TransientModel):
     @classmethod
     def _build_osv(cls):
         """Build the view for the current configuration."""
-        arch = ('<?xml version="1.0" encoding="utf-8"?>'
-                '<form string="Configuration Form">'
+        arch = ('<form string="Configuration Form">'
                 '<notebook colspan="4">')
 
         # Odoo server configuration


### PR DESCRIPTION
It's no longer supported in lxml:

      File "/opt/odoo/external-src/server-tools/server_environment/serv_config.py", line 228, in _build_osv
        cls._arch = etree.fromstring(arch)
      File "src/lxml/lxml.etree.pyx", line 3213, in lxml.etree.fromstring (src/lxml/lxml.etree.c:82934)
      File "src/lxml/parser.pxi", line 1814, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:124471)
    ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.